### PR TITLE
Bump pnpm version to 10.26.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/ryguy34/snkrs-scraper/issues"
   },
   "homepage": "https://github.com/ryguy34/snkrs-scraper#readme",
-  "packageManager": "pnpm@10.26.0",
+  "packageManager": "pnpm@10.26.2",
   "dependencies": {
     "axios": "^1.13.2",
     "cheerio": "^1.1.2",


### PR DESCRIPTION
This pull request makes a minor update to the project’s package manager version in the `package.json` file.

- Updated the `packageManager` field from `pnpm@10.26.0` to `pnpm@10.26.2` to ensure compatibility with the latest bug fixes and improvements.