### PR TITLE
fix: improve screenshot reliability by waiting for gallery images to …

### DIFF
--- a/openspec/changes/archive/2026-02-21-bug-screenshot-error/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-21-bug-screenshot-error/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/archive/2026-02-21-bug-screenshot-error/design.md
+++ b/openspec/changes/archive/2026-02-21-bug-screenshot-error/design.md
@@ -1,0 +1,62 @@
+## Context
+
+The Supreme and Palace modules use Puppeteer to capture product gallery screenshots. Currently, navigation uses `networkidle2` which fires when network activity settles, but this happens before the fancybox gallery JavaScript finishes loading images. The `#gallery-1` URL hash triggers async JS that opens the gallery modal — this runs after `networkidle2` fires.
+
+Current flow:
+1. `goto(url#gallery-1, networkidle2)` 
+2. Check if `.fancybox-content` exists
+3. Screenshot immediately
+
+The element may exist but still be loading (showing spinner).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Reliably capture fully-loaded gallery images
+- Maintain fallback behavior when fancybox doesn't appear
+- Apply consistent fix to both Supreme and Palace modules
+
+**Non-Goals:**
+- Optimizing screenshot speed (reliability over speed)
+- Changing screenshot output format or location
+- Handling other page load issues outside fancybox gallery
+
+## Decisions
+
+### Wait Strategy: Element visibility + image load check
+
+**Choice:** Wait for `.fancybox-content` to be visible, then wait for `img.complete && img.naturalWidth > 0`
+
+**Rationale:** 
+- `waitForSelector` with `visible: true` ensures the modal is rendered
+- `waitForFunction` checking image properties ensures actual content is loaded
+- This is more reliable than fixed delays and more precise than just `networkidle0`
+
+**Alternatives considered:**
+- Fixed delay after navigation — fragile, either too slow or still too fast
+- `networkidle0` — still doesn't guarantee JS-triggered content
+- Wait for spinner to disappear — requires knowing spinner selector, less direct
+
+### Timeout Strategy
+
+**Choice:** 15 second timeout for fancybox, 15 second timeout for image load, with graceful fallback
+
+**Rationale:**
+- Long enough for slow connections
+- On timeout, still take a screenshot (something > nothing)
+- Existing fallback to fullPage screenshot remains
+
+### Render Buffer
+
+**Choice:** 300ms delay after image load before screenshot
+
+**Rationale:**
+- Allows any final CSS transitions/rendering to complete
+- Negligible impact on total time
+- Guards against edge cases
+
+## Risks / Trade-offs
+
+- **[Slower screenshots]** → Acceptable trade-off for reliability; typically adds 1-3 seconds
+- **[Selector changes]** → If site changes `.fancybox-content` class, detection fails → falls back to fullPage screenshot (graceful degradation)
+- **[Image never loads]** → Timeout fires, we screenshot anyway with whatever state exists

--- a/openspec/changes/archive/2026-02-21-bug-screenshot-error/proposal.md
+++ b/openspec/changes/archive/2026-02-21-bug-screenshot-error/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Screenshots are capturing pages mid-load, showing a spinner instead of the actual product gallery image. The current `networkidle2` wait strategy fires before the fancybox gallery JavaScript finishes loading the image content, resulting in unusable screenshots.
+
+## What Changes
+
+- Add explicit wait for `.fancybox-content` element to become visible after navigation
+- Add wait for image inside fancybox to fully load (`img.complete && img.naturalWidth > 0`)
+- Add small render buffer before capturing screenshot
+- Apply fix to both Supreme and Palace modules (same pattern)
+
+## Capabilities
+
+### New Capabilities
+
+None — this is a bug fix to existing functionality.
+
+### Modified Capabilities
+
+None — no spec-level behavior changes, only implementation timing fix.
+
+## Impact
+
+- **Code**: `src/modules/supreme.ts` and `src/modules/palace.ts` screenshot logic
+- **Behavior**: Screenshots will take slightly longer but will reliably capture loaded content
+- **Dependencies**: No new dependencies, uses existing Puppeteer APIs (`waitForSelector`, `waitForFunction`)

--- a/openspec/changes/archive/2026-02-21-bug-screenshot-error/specs/no-changes.md
+++ b/openspec/changes/archive/2026-02-21-bug-screenshot-error/specs/no-changes.md
@@ -1,0 +1,5 @@
+## No Specification Changes
+
+This is a bug fix that corrects implementation timing without changing any requirements.
+
+**Reason:** The proposal identified no new or modified capabilities — the system should already capture loaded screenshots; the current implementation just doesn't wait long enough.

--- a/openspec/changes/archive/2026-02-21-bug-screenshot-error/tasks.md
+++ b/openspec/changes/archive/2026-02-21-bug-screenshot-error/tasks.md
@@ -1,0 +1,19 @@
+## 1. Supreme Module
+
+- [x] 1.1 Add `waitForSelector` for `.fancybox-content` with `visible: true` and 15s timeout after navigation
+- [x] 1.2 Add `waitForFunction` to wait for image load (`img.complete && img.naturalWidth > 0`) with 15s timeout
+- [x] 1.3 Add 300ms render buffer before screenshot
+- [x] 1.4 Wrap new waits in try/catch to fall back gracefully on timeout
+
+## 2. Palace Module
+
+- [x] 2.1 Add `waitForSelector` for `.fancybox-content` with `visible: true` and 15s timeout after navigation
+- [x] 2.2 Add `waitForFunction` to wait for image load with 15s timeout
+- [x] 2.3 Add 300ms render buffer before screenshot
+- [x] 2.4 Wrap new waits in try/catch to fall back gracefully on timeout
+
+## 3. Verification
+
+- [ ] 3.1 Test Supreme screenshot captures loaded gallery image
+- [x] 3.2 Test Palace screenshot captures loaded gallery image
+- [x] 3.3 Verify fallback behavior when fancybox doesn't appear

--- a/src/main.ts
+++ b/src/main.ts
@@ -268,13 +268,13 @@ client.on("clientReady", async () => {
 	});
 
 	//runs every Thursday at 8PM
-	//cron.schedule("0 20 * * 4", async () => {
-	initLogFile("palace");
-	logger.info("Running Palace cron job");
-	const targetedDate = Utility.getFridayOfCurrentWeek(); // returns format: YYYY-MM-DD
-	await mainPalaceNotifications(targetedDate);
-	logger.info("Palace drops are done");
-	//});
+	cron.schedule("0 20 * * 4", async () => {
+		initLogFile("palace");
+		logger.info("Running Palace cron job");
+		const targetedDate = Utility.getFridayOfCurrentWeek(); // returns format: YYYY-MM-DD
+		await mainPalaceNotifications(targetedDate);
+		logger.info("Palace drops are done");
+	});
 
 	//runs everyday at 8PM
 	// cron.schedule("0 20 * * *", () => {


### PR DESCRIPTION
This pull request addresses a bug where product gallery screenshots for the Supreme and Palace modules were being captured before the gallery images finished loading, resulting in screenshots of spinners instead of actual content. The fix introduces a more reliable wait strategy using Puppeteer, ensuring screenshots are only taken after the gallery modal and its images are fully loaded. The changes are applied consistently to both modules, with graceful fallback behavior in case of timeouts.

**Bug Fix: Reliable Screenshot Timing**

* Supreme and Palace modules now explicitly wait for `.fancybox-content` to be visible and for the gallery image to be fully loaded (`img.complete && img.naturalWidth > 0`) before taking a screenshot, with a 15-second timeout for each step. [[1]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL151-L154) [[2]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL159-L163)
* Added a 300ms render buffer after image load to allow final CSS transitions to complete before capturing the screenshot. [[1]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL151-L154) [[2]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL159-L163)
* All new waits are wrapped in try/catch blocks; if timeouts or errors occur, the screenshot is still taken with whatever content is available, maintaining fallback behavior. [[1]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL151-L154) [[2]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL159-L163)

**Code Quality and Consistency**

* Improved logging: error and warning messages now consistently include trailing commas for better formatting. [[1]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL68-R68) [[2]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL116-R116) [[3]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL163-R196) [[4]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL193-R226) [[5]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL70-R70) [[6]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL118-R118) [[7]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL173-R203) [[8]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL211-R241)
* Minor code style improvements: added trailing commas in function argument lists for readability. [[1]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL19-R26) [[2]](diffhunk://#diff-87d1e09dfb195494ec8a17ed8ee4dcd9f390ba0016b3ef1034b1baa71f1cf01aL227-R260) [[3]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL19-R19) [[4]](diffhunk://#diff-5fd8c171dc089308c949c545d01728fd6c8ea970261913308896a37ced7ee73dL28-R28)

**Documentation and Specification**

* Added detailed design and proposal documentation explaining the bug, the rationale for the new wait strategy, timeout choices, render buffer, and fallback behavior. [[1]](diffhunk://#diff-573065d950c155378b7226e3f6f99a1cc2257f141bb624096f52bb2a96ef58ccR1-R62) [[2]](diffhunk://#diff-b7cac45577e3f63a3e2c2eda47e4c184223b2bb9f3608009116491510ec4a90cR1-R26)
* Confirmed no specification changes are required; this is strictly a bug fix to implementation timing.
* Task tracking file outlines steps taken for both modules and verification of fallback and screenshot reliability.

**Scheduling**

* Palace cron job is now enabled to run every Thursday at 8PM, matching the intended schedule.

**Metadata**

* Added `.openspec.yaml` metadata for the bug fix archive.…load