### PR TITLE
rename Kith Monday Program channels

### DIFF
--- a/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/.openspec.yaml
+++ b/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-02-21

--- a/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/design.md
+++ b/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/design.md
@@ -1,0 +1,28 @@
+## Context
+
+The `Utility.getUpcomingMonday()` function returns a date string used as the Discord channel name for Kith Monday Program drops. Currently returns `"feb-24"` format, which doesn't indicate what the channel is for.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make Kith Monday Program channel names self-documenting by appending `-monday-program`
+
+**Non-Goals:**
+- Changing the API endpoint channel naming (`/kith/:title` remains unchanged)
+- Renaming existing Discord channels
+
+## Decisions
+
+**Append suffix to format string**
+
+Modify the return statement to append `"-monday-program"` to the existing date format:
+```typescript
+return format(nextMonday, "MMM-dd").toLowerCase() + "-monday-program";
+```
+
+*Rationale*: Simplest possible change. No new functions, no configuration, no breaking changes.
+
+## Risks / Trade-offs
+
+- **Longer channel names** → Acceptable trade-off for clarity
+- **Existing channels unaffected** → No migration needed, old channels keep their names

--- a/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/proposal.md
+++ b/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+The Kith Monday Program cron job creates Discord channels named only by date (e.g., `feb-24`), which doesn't clearly indicate what the channel is for. Adding `-monday-program` suffix makes the channel purpose immediately recognizable.
+
+## What Changes
+
+- Modify `Utility.getUpcomingMonday()` to return `"feb-24-monday-program"` format instead of `"feb-24"`
+- Channel names become more descriptive and self-documenting
+
+## Capabilities
+
+### New Capabilities
+
+None - this is a minor adjustment to existing functionality.
+
+### Modified Capabilities
+
+None - no spec-level behavior changes, just formatting of output.
+
+## Impact
+
+- **Code**: `src/utility/utility.ts` - `getUpcomingMonday()` function
+- **Discord**: Future Kith Monday Program channels will have longer names
+- **Existing channels**: Not affected (Discord channels already created keep their names)

--- a/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/specs/no-changes.md
+++ b/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/specs/no-changes.md
@@ -1,0 +1,5 @@
+## No Specification Changes
+
+This change modifies output formatting without changing any requirements.
+
+**Reason:** The proposal identified no new or modified capabilities — the channel naming format is an internal implementation detail, not a spec-level behavior. The system will continue to create channels for Kith Monday Program drops; only the name format changes.

--- a/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/tasks.md
+++ b/openspec/changes/archive/2026-02-21-rename-kith-monday-channel/tasks.md
@@ -1,0 +1,7 @@
+## 1. Implementation
+
+- [x] 1.1 Modify `getUpcomingMonday()` in `src/utility/utility.ts` to append `-monday-program` suffix
+
+## 2. Verification
+
+- [x] 2.1 Verify the function returns expected format (e.g., `feb-24-monday-program`)

--- a/src/utility/utility.ts
+++ b/src/utility/utility.ts
@@ -143,13 +143,13 @@ class Utility {
 	 * Gets the upcoming Monday date for Kith Monday Program drops.
 	 * If today is Monday, returns today's date.
 	 *
-	 * @returns Date string in lowercase mmm-dd format (e.g., "feb-24")
+	 * @returns Date string in lowercase mmm-dd-monday-program format (e.g., "feb-24-monday-program")
 	 */
 	static getUpcomingMonday(): string {
 		const today = new Date();
 		const daysUntilMonday = (8 - today.getDay()) % 7; // Calculate days until next Monday, 0 if today is Monday
 		const nextMonday = addDays(today, daysUntilMonday);
-		return format(nextMonday, "MMM-dd").toLowerCase(); // Format as "mmm-dd" and convert to lowercase
+		return format(nextMonday, "MMM-dd").toLowerCase() + "-monday-program";
 	}
 }
 


### PR DESCRIPTION
This pull request updates the naming convention for Discord channels created by the Kith Monday Program. Moving forward, new channels will have a more descriptive name by appending `-monday-program` to the date string, making their purpose clearer. No changes are made to existing channels or API endpoints, and there are no spec-level changes.

**Channel naming update:**

* Modified the `getUpcomingMonday()` function in `src/utility/utility.ts` to return date strings in the format `"mmm-dd-monday-program"` (e.g., `feb-24-monday-program`) instead of just `"mmm-dd"` (e.g., `feb-24`). This makes future channel names self-documenting and easier to identify.

**Documentation and planning:**

* Added context, rationale, and risk assessment for the naming change in `design.md`, clarifying the goal to improve clarity without affecting existing channels or endpoints.
* Outlined the motivation, impacted code, and scope of the change in `proposal.md`.
* Noted that this is not a specification change and does not alter requirements in `specs/no-changes.md`.
* Documented implementation and verification steps in `tasks.md`.
* Created a new change record in `.openspec.yaml` with the date and schema.…monday-program' suffix